### PR TITLE
Remove PageConfig

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,6 @@ dependencies:
 - aeson
 - base >= 4.7 && < 5
 - bytestring
-- persistent
 - text
 - unliftio
 - yesod-core

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,7 +22,8 @@ import Data.Scientific (Scientific)
 import Data.Text (Text, unpack)
 import Data.Time (UTCTime, getCurrentTime)
 import Database.Persist
-  ( Filter
+  ( Entity(entityKey)
+  , Filter
   , SelectOpt(Asc, LimitTo)
   , deleteWhere
   , insert
@@ -98,7 +99,7 @@ getSomeR = do
   teacherId <- requireParam "teacherId"
   mCourseId <- optionalParam "courseId"
 
-  page <- withPage entityPage $ \Cursor {..} -> runDB $ selectList
+  page <- withPage entityKey $ \Cursor {..} -> runDB $ selectList
     (catMaybes
       [ Just $ SomeAssignmentTeacherId ==. teacherId
       , (SomeAssignmentCourseId ==.) <$> mCourseId


### PR DESCRIPTION
- Use request `Host` for determining domain

  Fixes #4.

- Remove `PageConfig`

  Now that it's a single function we can inject it directly. Removing
  `entityPage` also means we can remove a dependency on `persistent` from our
  library target.