### PR TITLE
Add withPageLink

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,8 @@ library:
   source-dirs: src
   dependencies:
   - containers
+  - http-link-header
+  - network-uri
 
 tests:
   yesod-page-cursor-test:
@@ -35,6 +37,7 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hspec
+    - http-link-header
     - http-types
     - lens
     - lens-aeson


### PR DESCRIPTION
Usage and behavior is just like `withPage` except that it does not return a
`Page`, instead it adds a properly-formatted `Link` header to the response and
then returns only the `pageData` items.