### PR TITLE
Fix extra next links

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -123,7 +123,7 @@ makePaginationRoute withPage' = do
       , whereClause cursorPosition
       ]
     )
-    [LimitTo $ fromMaybe 100 cursorLimit, Asc persistIdField]
+    [LimitTo cursorLimit, Asc persistIdField]
   returnJson $ keyValueEntityToJSON <$> items
  where
   whereClause = \case
@@ -167,6 +167,17 @@ main = do
         addGetParam "teacherId" "1"
         addGetParam "limit" "3"
       assertDataKeys [1, 2]
+      mNext <- mayLink "next"
+      liftIO $ mNext `shouldBe` Nothing
+
+    yit "finds a null next even with limit defaulted" $ do
+      now <- liftIO getCurrentTime
+      runNoLoggingT . runDB' $ do
+        deleteAssignments
+        replicateM_ 2 . insert $ SomeAssignment 1 2 now
+      request $ do
+        setUrl SomeR
+        addGetParam "teacherId" "1"
       mNext <- mayLink "next"
       liftIO $ mNext `shouldBe` Nothing
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -181,6 +181,18 @@ main = do
       mNext <- mayLink "next"
       liftIO $ mNext `shouldBe` Nothing
 
+    yit "finds a null next even with page-aligned data" $ do
+      now <- liftIO getCurrentTime
+      runNoLoggingT . runDB' $ do
+        deleteAssignments
+        replicateM_ 2 . insert $ SomeAssignment 1 2 now
+      request $ do
+        setUrl SomeR
+        addGetParam "teacherId" "1"
+        addGetParam "limit" "2"
+      mNext <- mayLink "next"
+      liftIO $ mNext `shouldBe` Nothing
+
     yit "returns the same response for the same cursor" $ do
       now <- liftIO getCurrentTime
       runNoLoggingT . runDB' $ do


### PR DESCRIPTION
1. We were including a next link in a defaulted-limit case because we didn't
   know how to check if the length of our page was greater than the limit
   without it.

   To fix this, I decided to let the library own the defaulting to 100. Clients
   still have control by actually sending in a &limit parameter, we're just
   dropping the ability to let a Frontend omit it but a Backend control it
   specifically.

   I think it's a good direction to let the library own it, and might look to go
   further. For example, we have nothing preventing a client sending in large
   page-sizes and IMO the library could handle that. So owning the limit param
   generally (defaulting and validation) seems like a Good Thing to me, but I
   don't feel strongly.

1. That whole length-check doesn't work if the data is exactly a page-size

   To resolve this, we now over-fetch by one item and only return a next link if
   we get that. Annoying, but necessary.

   This removed the efficient fold-based length-and-last. It's probably possible
   to bring that back as length-and-second-to-last or something, but I chose not
   to. Also don't feel strongly on this point, but might have to defer to my
   reviewer and fold-expert to write that, if he prefers it.