### PR TITLE
Read limit, don't parse it as JSON

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -123,7 +123,7 @@ makePaginationRoute withPage' = do
       , whereClause cursorPosition
       ]
     )
-    [LimitTo cursorLimit, Asc persistIdField]
+    [LimitTo $ unLimit cursorLimit, Asc persistIdField]
   returnJson $ keyValueEntityToJSON <$> items
  where
   whereClause = \case
@@ -134,6 +134,15 @@ main :: IO ()
 main = do
   runNoLoggingT . runDB' $ runMigration migrateAll
   hspec . yesodSpec Simple $ ydescribe "Cursor" $ do
+    yit "responds with a useful message on invalid limit" $ do
+      request $ do
+        setUrl SomeR
+        addGetParam "teacherId" "1"
+        addGetParam "limit" "-1"
+
+      statusIs 400
+      bodyContains "must be positive and non-zero"
+
     yit "returns no cursor when there are no items" $ do
       runNoLoggingT . runDB' $ deleteAssignments
       request $ do


### PR DESCRIPTION
Fixes #3. As discussed there, the limit parameter is a simple number.
Parsing it as JSON works, but is superfluous. Reading it (via Read or
PathPiece) would function the same and be simpler, Read being simplest.

I chose to make a newtype for additional safety. Originally, I tried to
wrap a Natural, but in doing so I was alerted to a place where we call
(!!) with (limit - 1). The list we're indexing is guarded to be larger
then limit, making (!!) safe, but only for limit values greater than 0.

Therefore, I additionally assert that we're not given 0. And once I was
doing that kind of validation myself, there wasn't much Natural would be
giving me. And the operations we do with the underlying representations
are easier if we don't have to fromIntegral all over, so I kept it Int.